### PR TITLE
refactored assembly-units

### DIFF
--- a/src/pneumaticCraft/common/tileentity/IResettable.java
+++ b/src/pneumaticCraft/common/tileentity/IResettable.java
@@ -1,0 +1,10 @@
+package pneumaticCraft.common.tileentity;
+
+public interface IResettable {
+
+    /**
+     * Returns true when the machine is done resetting
+     * @return
+     */
+    public boolean reset();
+}

--- a/src/pneumaticCraft/common/tileentity/TileEntityAssemblyController.java
+++ b/src/pneumaticCraft/common/tileentity/TileEntityAssemblyController.java
@@ -58,7 +58,7 @@ public class TileEntityAssemblyController extends TileEntityPneumaticBase implem
         if(!worldObj.isRemote && firstRun)
             updateConnections();
     	
-        // curProgram must be available on the client, or we can't show program-problems in the gui
+        // curProgram must be available on the client, or we can't show program-problems in the GUI
 		if(curProgram == null && !goingToHomePosition && inventory[PROGRAM_INVENTORY_INDEX] != null && inventory[PROGRAM_INVENTORY_INDEX].getItem() == Itemss.assemblyProgram) {
 		    AssemblyProgram program = ItemAssemblyProgram.getProgramFromItem(inventory[PROGRAM_INVENTORY_INDEX].getItemDamage());
 		    curProgram = program;
@@ -157,61 +157,24 @@ public class TileEntityAssemblyController extends TileEntityPneumaticBase implem
 
     }
     
-    // this is temporary until we re-factor this class
-    private byte resetStep = 0;
-
     private void goToHomePosition(TileEntityAssemblyPlatform platform, TileEntityAssemblyIOUnit ioUnitImport, TileEntityAssemblyIOUnit ioUnitExport, TileEntityAssemblyDrill drill, TileEntityAssemblyLaser laser){
-    	if(this.goingToHomePosition && this.resetStep == 0)
-    		this.resetStep = 1;
     	
-    	switch(this.resetStep) {
-    	case 1:
-    		if((drill == null) || drill.reset())
-    			this.resetStep++;
-    		break;
-    	case 2:
-    		if((laser == null) || laser.reset())
-    			this.resetStep++;
-    		break;
-    	case 3:
-    		if((platform == null) || platform.openClaw())
-    			this.resetStep++;
-    		break;
-    	case 4:
-    		if((ioUnitImport == null) || ioUnitImport.reset())
-    			this.resetStep++;
-    		break;
-    	case 5:
-    		if((ioUnitExport == null) || ioUnitExport.reset())
-    			this.resetStep++;
-    		break;
-    	case 6:
-    		if((platform != null) && (platform.getHeldStack() != null)) {
-    			if(ioUnitExport != null) {
-    				if(!ioUnitExport.pickupItem(null))
-    					this.resetStep--; // reset exportUnit and re-check platform
-    			}
-    		} else
-    			this.resetStep++;
-    		break;
-    	case 7:
-    		this.goingToHomePosition = false;
-    		this.resetStep = 0;
-    		break;    		
-    	}
-    	/*
-    	if(drill != null && !drill.reset()){
-    	} else if(laser != null && !laser.reset()){
-    	} else if((ioUnitImport != null) && ioUnitImport.isDone()
-    			&& (platform != null) && (platform.getHeldStack() != null)
-    			&& (ioUnitExport != null) &&ioUnitExport.isDone()) {
-    		ioUnitExport.pickupItem(null);
-    	} else if(!ioUnitImport.reset()) {    		
-    	} else if(!ioUnitExport.reset()) {    		
-    	}
-    	else
-    		this.goingToHomePosition = false;
-    		*/
+    	boolean resetDone = true;
+    	
+    	 for(IResettable machine : new IResettable[] { drill, laser, ioUnitImport, platform, ioUnitExport  }) {
+             if((machine != null) && !machine.reset()) {
+            	 resetDone = false;
+            	 
+            	 if(machine == platform) {
+            		 if(ioUnitExport != null)
+            			 ioUnitExport.pickupItem(null);            		 
+            	 }
+            	 
+        		 break;            	 
+             }
+         }
+    	 
+    	 this.goingToHomePosition = !(this.foundAllMachines && resetDone);
     }
 
     public void addProblems(List<String> problemList){

--- a/src/pneumaticCraft/common/tileentity/TileEntityAssemblyPlatform.java
+++ b/src/pneumaticCraft/common/tileentity/TileEntityAssemblyPlatform.java
@@ -7,7 +7,7 @@ import pneumaticCraft.common.network.DescSynced;
 import pneumaticCraft.common.network.LazySynced;
 import pneumaticCraft.lib.TileEntityConstants;
 
-public class TileEntityAssemblyPlatform extends TileEntityBase implements IAssemblyMachine{
+public class TileEntityAssemblyPlatform extends TileEntityBase implements IAssemblyMachine, IResettable {
     @DescSynced
     private boolean shouldClawClose;
     @DescSynced
@@ -37,6 +37,11 @@ public class TileEntityAssemblyPlatform extends TileEntityBase implements IAssem
     
     public boolean isIdle() {
     	return(!this.shouldClawClose && this.isClawDone() && (this.inventory[0] == null));
+    }
+    
+    public boolean reset() {
+    	this.openClaw();
+    	return(this.isIdle());
     }
 
     public boolean closeClaw(){

--- a/src/pneumaticCraft/common/tileentity/TileEntityAssemblyRobot.java
+++ b/src/pneumaticCraft/common/tileentity/TileEntityAssemblyRobot.java
@@ -11,7 +11,7 @@ import pneumaticCraft.lib.TileEntityConstants;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-public abstract class TileEntityAssemblyRobot extends TileEntityBase implements IAssemblyMachine{
+public abstract class TileEntityAssemblyRobot extends TileEntityBase implements IAssemblyMachine, IResettable {
     public float[] oldAngles = new float[5];
     @DescSynced
     @LazySynced


### PR DESCRIPTION
goal: make the code more robust
means: make everything more verbose, simplify control-flow, avoid code-duplication

We can now (better) handle full inventories, changing inventories (e.g. moving a chest, placing a new chest) etc.

I also tried to avoid units crashing into each other (e.g. with speed upgrades installed, the export-unit would pick up an item before the drill has moved away, because it took longer to spin down), made sure that claws need to open/close before moving items etc.

I tested this for quite a while and was unable to break it, but by all means go ahead and try to brake it yourself, there might still be regressions that I overlooked. If nothing else, it should now be easier to fix any remaining issues.
