### PR TITLE
Changed OpenComputers integration to be indirect and properly implemented IPeripheral.equals().

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,2 @@
 -Added Programmable Controller!
+-Change to OpenComputers integration: Every block except for the Drone Interface now requires an Adapter placed next to it for the block to provide the functions it used to provide.

--- a/src/pneumaticCraft/common/thirdparty/computercraft/DriverPneumaticCraft.java
+++ b/src/pneumaticCraft/common/thirdparty/computercraft/DriverPneumaticCraft.java
@@ -1,0 +1,68 @@
+package pneumaticCraft.common.thirdparty.computercraft;
+
+import li.cil.oc.api.Network;
+import li.cil.oc.api.driver.NamedBlock;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedPeripheral;
+import li.cil.oc.api.network.Visibility;
+import li.cil.oc.api.prefab.DriverTileEntity;
+import li.cil.oc.api.prefab.ManagedEnvironment;
+import net.minecraft.world.World;
+import pneumaticCraft.common.tileentity.TileEntityPneumaticBase;
+
+import java.util.List;
+
+/**
+ * @author Vexatos
+ */
+public class DriverPneumaticCraft extends DriverTileEntity {
+
+    public static class InternalManagedEnvironment extends ManagedEnvironment implements ManagedPeripheral, NamedBlock {
+        protected final TileEntityPneumaticBase tile;
+
+        public InternalManagedEnvironment(TileEntityPneumaticBase tile) {
+            this.tile = tile;
+            this.setNode(Network.newNode(this, Visibility.Network).withComponent(this.tile.getType(), Visibility.Network).create());
+        }
+
+        @Override
+        public String preferredName() {
+            return tile.getType();
+        }
+
+        @Override
+        public int priority() {
+            return 20;
+        }
+
+        @Override
+        public String[] methods() {
+            return tile.getMethodNames();
+        }
+
+        @Override
+        public Object[] invoke(String method, Context context, Arguments args) throws Exception {
+            if("greet".equals(method)) {
+                return new Object[] { String.format("Hello, %s!", args.checkString(0)) };
+            }
+            List<ILuaMethod> luaMethods = tile.getLuaMethods();
+            for(ILuaMethod m : luaMethods) {
+                if(m.getMethodName().equals(method)) {
+                    return m.call(args.toArray());
+                }
+            }
+            throw new IllegalArgumentException("Can't invoke method with name \"" + method + "\". not registered");
+        }
+    }
+
+    @Override
+    public Class<?> getTileEntityClass() {
+        return TileEntityPneumaticBase.class;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, int x, int y, int z) {
+        return new InternalManagedEnvironment((TileEntityPneumaticBase) world.getTileEntity(x, y, z));
+    }
+}

--- a/src/pneumaticCraft/common/thirdparty/computercraft/OpenComputers.java
+++ b/src/pneumaticCraft/common/thirdparty/computercraft/OpenComputers.java
@@ -1,5 +1,6 @@
 package pneumaticCraft.common.thirdparty.computercraft;
 
+import li.cil.oc.api.Driver;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.init.Items;
@@ -32,6 +33,7 @@ public class OpenComputers implements IThirdParty{
         if(!Loader.isModLoaded(ModIds.COMPUTERCRAFT)) {
             GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(droneInterface), true, " u ", "mp ", "iii", 'u', new ItemStack(Itemss.machineUpgrade, 1, ItemMachineUpgrade.UPGRADE_RANGE), 'm', Items.ender_pearl, 'p', Itemss.printedCircuitBoard, 'i', Names.INGOT_IRON_COMPRESSED));
         }
+        Driver.add(new DriverPneumaticCraft());
     }
 
     @Override

--- a/src/pneumaticCraft/common/thirdparty/computercraft/TileEntityDroneInterface.java
+++ b/src/pneumaticCraft/common/thirdparty/computercraft/TileEntityDroneInterface.java
@@ -751,8 +751,20 @@ public class TileEntityDroneInterface extends TileEntity implements IPeripheral,
 
     @Override
     @Optional.Method(modid = ModIds.COMPUTERCRAFT)
-    public boolean equals(IPeripheral other){//TODO await documention on the method, so it can be correctly implemented.
-        return equals((Object)other);
+    public boolean equals(IPeripheral other){
+        if(other == null) {
+            return false;
+        }
+        if(this == other) {
+            return true;
+        }
+        if(other instanceof TileEntity) {
+            TileEntity tother = (TileEntity) other;
+            return tother.getWorldObj().equals(worldObj)
+                && tother.xCoord == this.xCoord && tother.yCoord == this.yCoord && tother.zCoord == this.zCoord;
+        }
+
+        return false;
     }
 
     private void sendEvent(String name, Object... parms){

--- a/src/pneumaticCraft/common/tileentity/TileEntityPneumaticBase.java
+++ b/src/pneumaticCraft/common/tileentity/TileEntityPneumaticBase.java
@@ -4,10 +4,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import li.cil.oc.api.machine.Arguments;
-import li.cil.oc.api.machine.Context;
-import li.cil.oc.api.network.ManagedPeripheral;
-import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -44,9 +40,9 @@ import dan200.computercraft.api.lua.LuaException;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 
-@Optional.InterfaceList({@Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = ModIds.COMPUTERCRAFT), @Optional.Interface(iface = "li.cil.oc.api.network.ManagedPeripheral", modid = ModIds.OPEN_COMPUTERS), @Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = ModIds.OPEN_COMPUTERS)})
+@Optional.InterfaceList({@Optional.Interface(iface = "dan200.computercraft.api.peripheral.IPeripheral", modid = ModIds.COMPUTERCRAFT)})
 public class TileEntityPneumaticBase extends TileEntityBase implements IManoMeasurable, IAirHandler,
-        IPneumaticPosProvider, IPeripheral, ManagedPeripheral, SimpleComponent{
+        IPneumaticPosProvider, IPeripheral{
     public float maxPressure;
     @GuiSynced
     public int volume;
@@ -413,16 +409,6 @@ public class TileEntityPneumaticBase extends TileEntityBase implements IManoMeas
     }
 
     @Override
-    public String getComponentName(){
-        return getType();
-    }
-
-    @Override
-    public String[] methods(){
-        return getMethodNames();
-    }
-
-    @Override
     public String[] getMethodNames(){
         String[] methodNames = new String[luaMethods.size()];
         for(int i = 0; i < methodNames.length; i++) {
@@ -431,16 +417,8 @@ public class TileEntityPneumaticBase extends TileEntityBase implements IManoMeas
         return methodNames;
     }
 
-    @Override
-    @Optional.Method(modid = ModIds.OPEN_COMPUTERS)
-    public Object[] invoke(String method, Context context, Arguments args) throws Exception{
-        if("greet".equals(method)) return new Object[]{String.format("Hello, %s!", args.checkString(0))};
-        for(ILuaMethod m : luaMethods) {
-            if(m.getMethodName().equals(method)) {
-                return m.call(args.toArray());
-            }
-        }
-        throw new IllegalArgumentException("Can't invoke method with name \"" + method + "\". not registered");
+    public List<ILuaMethod> getLuaMethods(){
+        return this.luaMethods;
     }
 
     @Override
@@ -463,8 +441,20 @@ public class TileEntityPneumaticBase extends TileEntityBase implements IManoMeas
 
     @Override
     @Optional.Method(modid = ModIds.COMPUTERCRAFT)
-    public boolean equals(IPeripheral other){//TODO await documention on the method, so it can be correctly implemented.
-        return this.equals((Object)other);
+    public boolean equals(IPeripheral other){
+        if(other == null) {
+            return false;
+        }
+        if(this == other) {
+            return true;
+        }
+        if(other instanceof TileEntity) {
+            TileEntity tother = (TileEntity) other;
+            return tother.getWorldObj().equals(worldObj)
+                && tother.xCoord == this.xCoord && tother.yCoord == this.yCoord && tother.zCoord == this.zCoord;
+        }
+
+        return false;
     }
 
     protected void addLuaMethods(){


### PR DESCRIPTION
Blocks can now be connected to an OpenComputers network using an Adapter. Tested on server and client, both with and without OpenComputers.

Also properly implemented IPeripheral.equals().