### PR TITLE
Attempt at fixing #485.

### DIFF
--- a/src/pneumaticCraft/common/thirdparty/computercraft/OpenComputers.java
+++ b/src/pneumaticCraft/common/thirdparty/computercraft/OpenComputers.java
@@ -1,5 +1,6 @@
 package pneumaticCraft.common.thirdparty.computercraft;
 
+import cpw.mods.fml.common.Optional;
 import li.cil.oc.api.Driver;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -33,6 +34,13 @@ public class OpenComputers implements IThirdParty{
         if(!Loader.isModLoaded(ModIds.COMPUTERCRAFT)) {
             GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(droneInterface), true, " u ", "mp ", "iii", 'u', new ItemStack(Itemss.machineUpgrade, 1, ItemMachineUpgrade.UPGRADE_RANGE), 'm', Items.ender_pearl, 'p', Itemss.printedCircuitBoard, 'i', Names.INGOT_IRON_COMPRESSED));
         }
+        if(Loader.isModLoaded(ModIds.OPEN_COMPUTERS)) {
+            initializeDrivers();
+        }
+    }
+
+    @Optional.Method(modid = ModIds.OPEN_COMPUTERS)
+    private void initializeDrivers(){
         Driver.add(new DriverPneumaticCraft());
     }
 


### PR DESCRIPTION
Hopefully fixes #485.
Still waiting for input from the people having reported the bug. The fix in here is fixing what I think could have caused the crash. I did not expect the ComputerCraft integration class to extend this one, meaning this class would get loaded even if OpenComputers isn't present. This should get rid of all references to the OpenComputers driver if OpenComputers isn't present.