### PR TITLE
Add missing @SideOnly(Side.CLIENT) annotations

### DIFF
--- a/src/pneumaticCraft/common/item/ItemPlasticPlants.java
+++ b/src/pneumaticCraft/common/item/ItemPlasticPlants.java
@@ -80,11 +80,13 @@ public class ItemPlasticPlants extends ItemPneumatic{
         texture[15] = registerSeed(reg, Textures.ICON_FLYING_FLOWER_LOCATION);
     }
 
+    @SideOnly(Side.CLIENT)
     public IIcon registerSeed(IIconRegister register, String texture){
         return register.registerIcon(texture + "Seeds");
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(int meta){
         return texture[meta % 16];
     }


### PR DESCRIPTION
Hello, I'm the creator of AgriCraft and I wanted to make your plants plantable on my crop sticks. I'm using some reflection to get some data about your plants. However server side the code caused a crash because of missing @SideOnly(Side.CLIENT) annotations when getting a method from your class (https://github.com/InfinityRaider/AgriCraft/blob/master/src/main/java/com/InfinityRaider/AgriCraft/compatibility/pneumaticcraft/PneumaticCraftHelper.java#L28).
For the crash log I refer to the issue on my github: https://github.com/InfinityRaider/AgriCraft/issues/234
