### PR TITLE
Make sure to load after ComputerCraft

### DIFF
--- a/src/pneumaticCraft/PneumaticCraft.java
+++ b/src/pneumaticCraft/PneumaticCraft.java
@@ -61,7 +61,7 @@ import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 
-@Mod(modid = Names.MOD_ID, name = "PneumaticCraft", guiFactory = "pneumaticCraft.client.GuiConfigHandler", dependencies = "required-after:Forge@[10.13.3.1388,);" + "after:Forestry")
+@Mod(modid = Names.MOD_ID, name = "PneumaticCraft", guiFactory = "pneumaticCraft.client.GuiConfigHandler", dependencies = "required-after:Forge@[10.13.3.1388,);" + "after:Forestry;after:ComputerCraft")
 public class PneumaticCraft{
 
     @SidedProxy(clientSide = "pneumaticCraft.proxy.ClientProxy", serverSide = "pneumaticCraft.proxy.CommonProxy")


### PR DESCRIPTION
If another mod requires PneumaticCraft, but is loaded before ComputerCraft (e.g. CompactMachines) then PneumaticCraft will fail to load because of missing (not yet loaded) API interfaces.
An issue caused by this can be found here:
https://github.com/thraaawn/CompactMachines/issues/162